### PR TITLE
Fix or1k-shiftopts exit status

### DIFF
--- a/native/or1k/or1k-shiftopts.S
+++ b/native/or1k/or1k-shiftopts.S
@@ -103,6 +103,8 @@
 	
 	l.movhi	r3, 0x6000
 	l.ori	r3,r3,0x000d
+	l.nop	2
+	l.ori	r3, r0, 0
 	l.nop 	1
 
 


### PR DESCRIPTION
Exit code was not set when test was successfully completed
