### PR TITLE
Fixup build for new toolchain, add a test runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.o
 *.a
 build/
+*.log

--- a/native/Makefile
+++ b/native/Makefile
@@ -20,7 +20,7 @@ libs:
 
 $(STARGETS): $(BUILDDIR)/%: %.S
 	@mkdir -p $(dir $@)
-	$(CC) -Iinclude -Iinclude/$(TARGET) $(CFLAGS) -Llib $< -lsupport -o $@
+	$(CC) -nostartfiles -Iinclude -Iinclude/$(TARGET) $(CFLAGS) -Llib $< -lsupport -o $@
 
 clean:
 	make -C lib/ clean

--- a/native/lib/cache.S
+++ b/native/lib/cache.S
@@ -1,20 +1,19 @@
 #include <or1k-sprs.h>
 #include <or1k-asm.h>
-	
+
 	/* Cache init. To be called during init ONLY */
-	
+
 	.global	_cache_init
         .type	_cache_init,@function
 
-_cache_init:	
+_cache_init:
 	/* Instruction cache enable */
 	/* Check if IC present and skip enabling otherwise */
 	l.mfspr r3,r0,OR1K_SPR_SYS_UPR_ADDR
 	l.andi  r4,r3,OR1K_SPR_SYS_UPR_ICP_MASK
 	l.sfeq  r4,r0
 	OR1K_DELAYED_NOP(OR1K_INST(l.bf    .L8))
-	
-	
+
 	/* Disable IC */
 	l.mfspr r6,r0,OR1K_SPR_SYS_SR_ADDR
 	l.addi  r5,r0,-1
@@ -32,7 +31,7 @@ _cache_init:
 	l.srli  r5,r4,7
 	l.ori   r6,r0,16
 	l.sll   r14,r6,r5
-	
+
 	/* Establish number of cache sets
 	r7 contains number of cache sets
 	r5 contains log(# of cache sets)
@@ -41,11 +40,11 @@ _cache_init:
 	l.srli  r5,r4,3
 	l.ori   r6,r0,1
 	l.sll   r7,r6,r5
-	
+
 	/* Invalidate IC */
 	l.addi  r6,r0,0
 	l.sll   r5,r14,r5
-	
+
 .L7:
 	l.mtspr r0,r6,OR1K_SPR_ICACHE_ICBIR_ADDR
 	l.sfne  r6,r5
@@ -53,7 +52,7 @@ _cache_init:
 	OR1K_INST(l.add   r6,r6,r14),
 	OR1K_INST(l.bf    .L7)
 	)
-	
+
 	/* Enable IC */
 	l.mfspr r6,r0,OR1K_SPR_SYS_SR_ADDR
 	l.ori   r6,r6,OR1K_SPR_SYS_SR_ICE_MASK

--- a/native/or1k/or1k-alignillegalinsn.S
+++ b/native/or1k/or1k-alignillegalinsn.S
@@ -2,21 +2,21 @@
 	Exception test.
 
 	The following list outlines the tests performed
-	
+
 	Execption tests for:
-	- 0x100 reset                        - start addr after reset 
+	- 0x100 reset                        - start addr after reset
 	- 0x200 bus error                    - unimplemented addr is accessed
 	- 0x600 alignment                    - write to unaligned addr
-	- 0x700 illegal instruction          - use unimplemented inst. l.div 
-	
-	r11 - 1st exception counter incremented inside exception 
+	- 0x700 illegal instruction          - use unimplemented inst. l.div
+
+	r11 - 1st exception counter incremented inside exception
 	r12 - 2nd exception counter incremented outside and rigth after
 	      exception
 	... other register use to be documented...
 
 	Julius Baxter, julius@opencores.org
 	Tadej Markovic, tadej@opencores.org
-	
+
 */
 //////////////////////////////////////////////////////////////////////
 ////                                                              ////
@@ -48,13 +48,13 @@
 #include <or1k-asm.h>
 #include <or1k-sprs.h>
 #include "board.h"
-	
+
 /* =================================================== [ exceptions ] === */
 	.section .vectors, "ax"
 
 
 /* ---[ 0x100: RESET exception ]----------------------------------------- */
-        .org 0x100 	
+	.org 0x100
 	l.movhi r0, 0
 	/* Clear status register */
 	l.ori 	r1, r0, OR1K_SPR_SYS_SR_SM_MASK
@@ -72,13 +72,13 @@
 	l.movhi r4, hi(_start)
 	l.ori 	r4, r4, lo(_start)
 	l.jr    r4
-	l.nop
+	 l.nop
 
-  
+
 /* ---[ 0x200: BUS error ]------------------------------------------------ */
 	.org 0x200
 	.global	_bus_handler
-	
+
 _bus_handler:
 	l.ori	r7,r0,1		/* set "exception flag" */
 	l.mfspr	r3,r0,OR1K_SPR_SYS_EPCR_BASE	/* Get EPC */
@@ -104,7 +104,7 @@ _bus_handler:
 /* ---[ 0x600: ALIGN error ]------------------------------------------------ */
 	.org 0x600
 	.global	_align_handler
-_align_handler:	
+_align_handler:
 	l.mfspr	r3,r0,OR1K_SPR_SYS_EPCR_BASE	/* Get EPC */
 	l.nop	2
 	l.addi	r11,r11,1		/* Increment 1st exception counter */
@@ -139,18 +139,18 @@ _illinsn_handler:
 /* =================================================== [ start ] === */	
 
 	.global _start
-_start:	
+_start:
 	l.jal 	_cache_init
-	l.nop
+	 l.nop
 	// Kick off test
 	l.jal   _main
-	l.nop
+	 l.nop
 
 /* ========================================================= [ main ] === */
 
 	.global	_main
-_main:		
-	l.nop	
+_main:
+	l.nop
         l.addi	r3,r0,0
         l.addi	r5,r0,0
         l.addi	r11,r0,0 /* exception counter 1 */
@@ -158,26 +158,26 @@ _main:
         l.addi	r13,r0,0
 	l.addi	r14,r0,0 /* DMMU exception counter for low mem mapping */
 	l.addi	r15,r0,0 /* DMMU exception counter for hi mem mapping */
-	l.sw	0x0(r0),r0	/* Initialize RAM */	
-	l.sw	0x4(r0),r0	/* Initialize RAM */	
-	l.sw	0x8(r0),r0	/* Initialize RAM */	
-	l.sw	0xc(r0),r0	/* Initialize RAM */	
-	l.sw	0x10(r0),r0	/* Initialize RAM */	
-	l.sw	0x14(r0),r0	/* Initialize RAM */	
-	l.sw	0x18(r0),r0	/* Initialize RAM */	
-	l.sw	0x1c(r0),r0	/* Initialize RAM */	
-	l.sw	0x20(r0),r0	/* Initialize RAM */	
-	l.sw	0x24(r0),r0	/* Initialize RAM */	
-	l.sw	0x28(r0),r0	/* Initialize RAM */	
-	l.sw	0x2c(r0),r0	/* Initialize RAM */	
-	l.sw	0x30(r0),r0	/* Initialize RAM */	
-	l.sw	0x34(r0),r0	/* Initialize RAM */	
-	l.sw	0x38(r0),r0	/* Initialize RAM */	
-	l.sw	0x3c(r0),r0	/* Initialize RAM */	
-	l.sw	0x40(r0),r0	/* Initialize RAM */	
-	l.sw	0x44(r0),r0	/* Initialize RAM */	
-	l.sw	0x48(r0),r0	/* Initialize RAM */	
-	l.sw	0x4c(r0),r0	/* Initialize RAM */	
+	l.sw	0x0(r0),r0	/* Initialize RAM */
+	l.sw	0x4(r0),r0	/* Initialize RAM */
+	l.sw	0x8(r0),r0	/* Initialize RAM */
+	l.sw	0xc(r0),r0	/* Initialize RAM */
+	l.sw	0x10(r0),r0	/* Initialize RAM */
+	l.sw	0x14(r0),r0	/* Initialize RAM */
+	l.sw	0x18(r0),r0	/* Initialize RAM */
+	l.sw	0x1c(r0),r0	/* Initialize RAM */
+	l.sw	0x20(r0),r0	/* Initialize RAM */
+	l.sw	0x24(r0),r0	/* Initialize RAM */
+	l.sw	0x28(r0),r0	/* Initialize RAM */
+	l.sw	0x2c(r0),r0	/* Initialize RAM */
+	l.sw	0x30(r0),r0	/* Initialize RAM */
+	l.sw	0x34(r0),r0	/* Initialize RAM */
+	l.sw	0x38(r0),r0	/* Initialize RAM */
+	l.sw	0x3c(r0),r0	/* Initialize RAM */
+	l.sw	0x40(r0),r0	/* Initialize RAM */
+	l.sw	0x44(r0),r0	/* Initialize RAM */
+	l.sw	0x48(r0),r0	/* Initialize RAM */
+	l.sw	0x4c(r0),r0	/* Initialize RAM */
 	l.j	_align1
 	l.nop
 
@@ -185,7 +185,7 @@ _main:
         /* Exceptions followed by NOPs */
 
 	/* SW alignment exception */
-_align1:	
+_align1:
 	l.movhi r11,0
 	l.nop
 	/* Test l.sh */
@@ -207,89 +207,89 @@ _align1:
 	l.lhs 	r3,0x0(r5)
 	l.addi	r12,r12,1 /* Increment 2nd exception counter */
 	l.ori	r5,r0,0x3 /* Half-word access, offset 3 */
-	l.lhs	r3,0x0(r5)	
+	l.lhs	r3,0x0(r5)
 	l.addi	r12,r12,1 /* Increment 2nd exception counter */
 	/* Test l.sw */
-	l.ori	r5,r0,0x1 /* Word access, offset 1 */	
+	l.ori	r5,r0,0x1 /* Word access, offset 1 */
 	l.sw	0x0(r5), r0
 	l.addi	r12,r12,1 /* Increment 2nd exception counter */
-	l.ori	r5,r0,0x2 /* Word access, offset 2 */	
+	l.ori	r5,r0,0x2 /* Word access, offset 2 */
 	l.sw	0x0(r5), r0
 	l.addi	r12,r12,1 /* Increment 2nd exception counter */
-	l.ori	r5,r0,0x3 /* Word access, offset 3 */	
+	l.ori	r5,r0,0x3 /* Word access, offset 3 */
 	l.sw	0x0(r5), r0
 	l.addi	r12,r12,1 /* Increment 2nd exception counter */
 	/* Test l.lwz */
-	l.ori	r5,r0,0x1 /* Word access, offset 1 */	
+	l.ori	r5,r0,0x1 /* Word access, offset 1 */
 	l.lwz	r3,0x0(r5)
 	l.addi	r12,r12,1 /* Increment 2nd exception counter */
-	l.ori	r5,r0,0x2 /* Word access, offset 2 */	
+	l.ori	r5,r0,0x2 /* Word access, offset 2 */
 	l.lwz	r3,0x0(r5)
 	l.addi	r12,r12,1 /* Increment 2nd exception counter */
-	l.ori	r5,r0,0x3 /* Word access, offset 3 */	
+	l.ori	r5,r0,0x3 /* Word access, offset 3 */
 	l.lwz	r3,0x0(r5)
 	l.addi	r12,r12,1 /* Increment 2nd exception counter */
 	/* Test l.lws */
-	l.ori	r5,r0,0x1 /* Word access, offset 1 */	
+	l.ori	r5,r0,0x1 /* Word access, offset 1 */
 	l.lws	r3,0x0(r5)
 	l.addi	r12,r12,1 /* Increment 2nd exception counter */
-	l.ori	r5,r0,0x2 /* Word access, offset 2 */	
+	l.ori	r5,r0,0x2 /* Word access, offset 2 */
 	l.lws	r3,0x0(r5)
 	l.addi	r12,r12,1 /* Increment 2nd exception counter */
-	l.ori	r5,r0,0x3 /* Word access, offset 3 */	
-	l.lws	r3,0x0(r5)	
+	l.ori	r5,r0,0x3 /* Word access, offset 3 */
+	l.lws	r3,0x0(r5)
 	l.addi	r12,r12,1 /* Increment 2nd exception counter */
 	l.nop
 
 #ifdef __OR1K_DELAY__
 	/* Now test them in delay slots */
 	l.ori	r5,r0,0x1 /* Half-word access, offset 1 */
-	l.j	1f  
+	l.j	1f
 	l.sh	0x0(r5),r0
 	l.nop
 1:	l.addi	r12,r12,1 /* Increment 2nd exception counter */
 	l.ori	r5,r0,0x3 /* Half-word access, offset 3 */
-	l.j	2f  	
+	l.j	2f
 	l.sh	0x0(r5),r0
-	l.nop	
+	l.nop
 2:	l.addi	r12,r12,1 /* Increment 2nd exception counter */
 
 	/* Test l.lhz */
 	l.ori	r5,r0,0x1 /* Half-word access, offset 1 */
 	l.j	3f
 	l.lhz	r3,0x0(r5)
-	l.nop	
+	l.nop
 3:	l.addi	r12,r12,1 /* Increment 2nd exception counter */
 	l.ori	r5,r0,0x3 /* Half-word access, offset 3 */
 	l.j	4f
 	l.lhz	r3,0x0(r5)
 	l.nop
 4:	l.addi	r12,r12,1 /* Increment 2nd exception counter */
-	
+
 	/* Test l.lhs */
 	l.ori	r5,r0,0x1 /* Half-word access, offset 1 */
 	l.j	5f
 	l.lhs	r3,0x0(r5)
-	l.nop	
+	l.nop
 5:	l.addi	r12,r12,1 /* Increment 2nd exception counter */
 	l.ori	r5,r0,0x3 /* Half-word access, offset 3 */
 	l.j	6f
 	l.lhs	r3,0x0(r5)
 	l.nop
 6:	l.addi	r12,r12,1 /* Increment 2nd exception counter */
-	
+
 	/* Test l.sw */
-	l.ori 	r5,r0,0x1 /* Word access, offset 1 */     
+	l.ori 	r5,r0,0x1 /* Word access, offset 1 */
 	l.j 	7f
 	l.sw 	0x0(r5), r0
-	l.nop	
+	l.nop
 7:	l.addi 	r12,r12,1 /* Increment 2nd exception counter */
-	l.ori 	r5,r0,0x2 /* Word access, offset 2 */     
+	l.ori 	r5,r0,0x2 /* Word access, offset 2 */
 	l.j 	8f
 	l.sw 	0x0(r5), r0
-	l.nop	
+	l.nop
 8:	l.addi 	r12,r12,1 /* Increment 2nd exception counter */
-	l.ori 	r5,r0,0x3 /* Word access, offset 3 */     
+	l.ori 	r5,r0,0x3 /* Word access, offset 3 */
 	l.j 	9f
 	l.sh 	0x0(r5), r0
 	l.nop
@@ -315,37 +315,37 @@ _align1:
 	/* Test l.lws */
 	l.ori 	r5,r0,0x1 /* Word access, offset 1 */
 	l.j 	13f
-	l.lws 	r3,0x0(r5)
+	 l.lws 	r3,0x0(r5)
 	l.nop
 13:	l.addi 	r12,r12,1 /* Increment 2nd exception counter */
 	l.ori 	r5,r0,0x2 /* Word access, offset 2 */
 	l.j 	14f
-	l.lws 	r3,0x0(r5)
+	 l.lws 	r3,0x0(r5)
 	l.nop
 14:	l.addi 	r12,r12,1 /* Increment 2nd exception counter */
 	l.ori 	r5,r0,0x3 /* Word access, offset 3 */
 	l.j 	15f
-	l.lws 	r3,0x0(r5)
+	 l.lws 	r3,0x0(r5)
 	l.nop
 15:	l.addi 	r12,r12,1 /* Increment 2nd exception counter */
 
 #endif
-	
+
 	/* Check 1st and 2nd exception counters are equal */
 	l.sfeq	r11,r12			/* Should be equal */
 	l.bf	17f
-	l.nop
+	 l.nop
 	l.nop	1
 17:	l.nop	2
 	l.nop
 
 	/* Illegal instruction exception */
-_illegal1:	
+_illegal1:
 	l.nop
 	l.nop
 	l.movhi r5, hi(0x44004800) /* Put "l.jr r9" instruction in r5 */
 	l.ori 	r5, r5, lo(0x44004800)
-	l.sw 	0x0(r0), r5 	/* Write "l.j r9" to address 0x0 in RAM */	
+	l.sw 	0x0(r0), r5 	/* Write "l.j r9" to address 0x0 in RAM */
 	l.movhi r5, 0xee00 	/* Put an illegal instruction in r5 */
 	l.sw 	0x4(r0), r5   	/* Write illegal instruction to RAM addr 0x4 */
 	l.movhi r5, 0x1500 	/* l.nop after illegal instruction */
@@ -357,25 +357,25 @@ _illegal1:
 	OR1K_INST(l.addi 	r12,r12,1),      /* Increment 2nd exception counter */
 	OR1K_INST(l.jalr 	r6) 		/* Jump to address 0x4, land on illegal insn */
  	)
-	l.nop 			/* Should return here */	
+	l.nop 			/* Should return here */
 	l.nop
 
 #ifdef __OR1K_DELAY__
 	/* Test in delay slot */
-	
+
 	l.movhi r5, 0xee00 	/* Put an illegal instruction in r5 */
 	l.sw 	0x4(r0), r5   	/* Write illegal instruction to RAM addr 0x4 */
-	l.mtspr r0,r0,OR1K_SPR_ICACHE_ICBIR_ADDR /* Invalidate line 0 of cache */	
+	l.mtspr r0,r0,OR1K_SPR_ICACHE_ICBIR_ADDR /* Invalidate line 0 of cache */
 	l.jalr 	r0 /* Jump to address 0, will be a jump back but with an illegal
 	             dslot instruction which will befixed by handler */
-	l.addi 	r12,r12,1 	/* Increment 2nd exception counter */
+	 l.addi 	r12,r12,1 	/* Increment 2nd exception counter */
 	l.nop 			/* Should return here */
 #endif
-	
+
 	/* Check 1st and 2nd exception counters are equal */
 	l.sfeq	r11,r12		/* Should be equal */
 	l.bf 	1f
-	l.nop
+	 l.nop
 	l.or 	r3, r12, r12
 	l.nop 	2 		/* Report expected exception count */
 	l.or 	r3, r11, r11
@@ -383,7 +383,7 @@ _illegal1:
 	l.nop 	1
 1:	l.nop
 	l.nop
-	
+
 
 _dbus1:
 	l.nop
@@ -391,9 +391,9 @@ _dbus1:
 	l.movhi r11, 0
 	l.ori r2, r0, 0xd /* put 0xd in r2, indicate it's databus test */
 	/* Cause access error */
-	/* Load word */	
+	/* Load word */
 	l.movhi r5, 0xee00 /* Address to cause an error */
-	l.lwz r6, 0(r5) 
+	l.lwz r6, 0(r5)
 	l.addi r12, r12, 1 /* Incremement secondary exception counter */
 	/* Load half */	
 	l.movhi r5, 0xee00 /* Address to cause an error */
@@ -472,7 +472,7 @@ _dbus1:
 5:	l.sfeqi	r7, 0
 	l.bf	5b		/* wait for "exception flag" */
 	 l.nop
-	l.addi r12, r12, 1	
+	l.addi r12, r12, 1
 
 	l.movhi	r7, 0		/* clear "exception flag" */
 	/* Store byte */
@@ -483,9 +483,9 @@ _dbus1:
 6:	l.sfeqi	r7, 0
 	l.bf	6b		/* wait for "exception flag" */
 	 l.nop
-	l.addi r12, r12, 1	
+	l.addi r12, r12, 1
 #endif
-	
+
 /* Check 1st and 2nd exception counters are equal */
 	l.sfeq	r11,r12			/* Should be equal */
 	l.bf 7f
@@ -497,10 +497,9 @@ _dbus1:
 	l.nop 1
 7:	l.nop
 
-	
-	
+
 _ibus1:
-	/* TODO: do this it with cache enabled/disabled */	
+	/* TODO: do this it with cache enabled/disabled */
 	l.movhi r12, 0 /* Reset exception counters */
 	l.movhi r11, 0
 	l.movhi r2, 0x0 /* put 0x0 in r2,indicate it's instruction bus test*/
@@ -511,22 +510,22 @@ _ibus1:
 	l.addi r12, r12, 1 /* Incremement secondary exception counter */
 	/* Check 1st and 2nd exception counters are equal */
 	l.sfeq	r11,r12			/* Should be equal */
-	l.bf 1f
-	l.nop
+	l.bf test_ok
+	 l.nop
+
+test_fail:
 	l.or r3, r12, r12
 	l.nop 2 /* Report expected exception count */
 	l.or r3, r11, r11
 	l.nop 2 /* Report actual exception count */
 	l.nop 1
-1:	l.nop
-	l.nop	
-	
+
 	/* End of tests - report and finish simulation */
+test_ok:
 	l.movhi	r3,hi(0x8000000d)
 	l.ori	r3,r3,lo(0x8000000d)
 	l.nop	2
 
-	l.addi r3,r0,0
-	l.jal	exit
-	l.nop
+	l.movhi	r3,0x0
+	l.nop	0x1
 

--- a/native/or1k/or1k-cy.S
+++ b/native/or1k/or1k-cy.S
@@ -15,7 +15,7 @@
 TODO:	 Substraction carry out testing.
 
 	Julius Baxter, ORSoC AB, julius.baxter@orsoc.se
-	
+
 */
 //////////////////////////////////////////////////////////////////////
 ////                                                              ////
@@ -43,18 +43,18 @@ TODO:	 Substraction carry out testing.
 //// from http://www.opencores.org/lgpl.shtml                     ////
 ////                                                              ////
 //////////////////////////////////////////////////////////////////////
-	
-	
+
+
 #include <or1k-asm.h>
 #include <or1k-sprs.h>
 #include "board.h"
-		
+
 /* =================================================== [ exceptions ] === */
 	.section .vectors, "ax"
 
 
 /* ---[ 0x100: RESET exception ]----------------------------------------- */
-        .org 0x100 	
+        .org 0x100
 	l.movhi r0, 0
 	/* Clear status register */
 	l.ori r1, r0, OR1K_SPR_SYS_SR_SM_MASK
@@ -69,14 +69,16 @@ TODO:	 Substraction carry out testing.
 	l.jr    r4
 	l.nop
 
-	.org 0x600 	
+	.org 0x600
+	// Load store alignment exception
+	l.ori 	r3, r0, 0x600
 	l.nop 0x1
 
-	
+
 /* ---[ 0x700: Illegal instruction exception ]-------------------------- */
         .org 0x700
 	// Instruction not supported
-	l.ori 	r3, r0, 1
+	l.ori 	r3, r0, 0x700
 	l.nop 	0x1
 
 /* ---[ 0xb00: Range exception ]---------------------------------------- */
@@ -101,7 +103,7 @@ _start:
 	l.movhi	r4, 0
 	l.movhi	r5, 0
 	l.movhi	r6, 0
-	
+
 	// Kick off test
 	l.jal   _main
 	l.nop
@@ -115,16 +117,16 @@ _start:
 	l.andi	r6, r6, OR1K_SPR_SYS_SR_CY_MASK ;	\
 	l.sfne	r6, r0		  ;	\
 	l.bf	_fail		  ;	\
-	l.nop				
+	 l.nop
 
 #define CHECK_CY_SET			\
 	l.mfspr	r6, r0, OR1K_SPR_SYS_SR_ADDR	;	\
 	l.andi	r6, r6, OR1K_SPR_SYS_SR_CY_MASK ;	\
 	l.sfnei	r6, OR1K_SPR_SYS_SR_CY_MASK	  ;	\
 	l.bf	_fail		  ;	\
-	l.nop				
-	
-	.global _main	
+	 l.nop
+
+	.global _main
 _main:
 
 	// Set up some values, check the CY bit is cleared from reset
@@ -143,7 +145,7 @@ _main:
 
 	l.add	r3, r0, r0	;// Should clear CY
 	CHECK_CY_CLEAR
-	
+
 	l.addi	r3, r4, 0x1001	;// Should set CY
 	l.nop 	0x2
 	CHECK_CY_SET
@@ -163,7 +165,7 @@ _main:
 
 	l.sfnei	r3, 0x1002
 	l.bf	_fail
-	l.nop
+	 l.nop
 
 	l.add	r3, r4, r5	;// Should set CY
 	l.nop			;// 1 delay instruction
@@ -172,7 +174,7 @@ _main:
 
 	l.sfnei	r3, 0x1002
 	l.bf	_fail
-	l.nop
+	 l.nop
 
 	l.add	r3, r4, r5	;// Should set
 	l.nop	0x2		;// 1 delay instruction
@@ -182,11 +184,11 @@ _main:
 
 	l.sfnei	r3, 0x1002
 	l.bf	_fail
-	l.nop
+	 l.nop
 
 	l.add	r3, r0, r0	;// Should clear CY
-	CHECK_CY_CLEAR	
-	
+	CHECK_CY_CLEAR
+
 	// Check use of carry - l.addic
 	l.addi	r3, r4, 0x1001	;// Should set CY
 	;; // Consequtive instructions
@@ -195,7 +197,7 @@ _main:
 
 	l.sfnei	r3, 0x2
 	l.bf	_fail
-	l.nop
+	 l.nop
 
 	l.add	r3, r0, r0	;// Should clear CY
 	CHECK_CY_CLEAR
@@ -207,7 +209,7 @@ _main:
 
 	l.sfnei	r3, 0x2
 	l.bf	_fail
-	l.nop
+	 l.nop
 
 	l.add	r3, r0, r0	;// Should clear CY
 	CHECK_CY_CLEAR
@@ -220,10 +222,10 @@ _main:
 
 	l.sfnei	r3, 0x2
 	l.bf	_fail
-	l.nop
+	 l.nop
 
 	l.add	r3, r0, r0	;// Should clear CY
-	CHECK_CY_CLEAR	
+	CHECK_CY_CLEAR
 
 	// Add with carry and generate carry with l.addc
 
@@ -233,22 +235,22 @@ _main:
 
 	l.sfnei	r3, 0x1
 	l.bf	_fail
-	l.nop
+	 l.nop
 
 	CHECK_CY_SET
 
 	l.add	r3, r0, r0	;// Should clear CY
-	CHECK_CY_CLEAR		
+	CHECK_CY_CLEAR
 
 	// Add with carry and generate carry with l.addic
-	
+
 	l.addi	r3, r4, 0x1001
 	l.addic	r3, r4, 0x1001
 	l.nop	0x2
 
 	l.sfnei	r3, 0x1
 	l.bf	_fail
-	l.nop
+	 l.nop
 
 	CHECK_CY_SET
 
@@ -266,7 +268,7 @@ _main:
 
 	// WARNING - this will not work for the 3-stage multiplier
 	// in the mor1kx, as it will not detect unsigned overflow.
-	
+
 	// Now multiply 0x80000000 by 2 - should just overflow (for 32-bit)
 	l.mulu	r3, r5, r8
 	l.nop 	0x2
@@ -276,11 +278,11 @@ _main:
 	l.nop	0x2
 	CHECK_CY_CLEAR
 
-_finish:	
+_finish:
 	l.movhi r3, hi(0x8000000d)
 	l.ori 	r3, r3, lo(0x8000000d)
 	l.nop 	0x2
-	l.ori 	r3, r0, 0	
+	l.ori 	r3, r0, 0
 	l.nop 	0x1
 
 _fail:

--- a/native/or1k/or1k-dsxinsn.S
+++ b/native/or1k/or1k-dsxinsn.S
@@ -10,13 +10,13 @@
 	instruction in a delay slot. To do this, we need to have a
 	branch instruction as the very last instruction of a page,
 	with the delay slot instruction being on a new unmapped page.
-	
+
 	Set r10 to hold whether we are expecting SR[DSX] to be set or
 	not. Exceptions will advance the PC by 0x8 to step over both
 	the jump/branch and instruction causing an exception.
 
 	Julius Baxter <juliusbaxter@gmail.com>
-	
+
 */
 //////////////////////////////////////////////////////////////////////
 ////                                                              ////
@@ -56,7 +56,7 @@
 
 
 /* ---[ 0x100: RESET exception ]----------------------------------------- */
-        .org 0x100 	
+	.org 0x100
 	l.movhi r0, 0
 	/* Clear status register */
 	l.ori 	r1, r0, OR1K_SPR_SYS_SR_SM_MASK
@@ -70,46 +70,47 @@
 	l.addi  r2, r0, -3
 	l.and   r1, r1, r2
 	/* Jump to program initialisation code */
+
 	.global _start
 	l.movhi r4, hi(_start)
 	l.ori 	r4, r4, lo(_start)
 	l.jr    r4
-	l.nop
-  
+	 l.nop
+
 /* ---[ 0x200: BUS error ]------------------------------------------------ */
 	.org 0x200
 	l.j	test_fail
-	l.nop
-	
+	 l.nop
+
 /* ---[ 0x600: ALIGN error ]------------------------------------------------ */
 	.org 0x600
 	l.j	test_fail
-	l.nop
-	
+	 l.nop
+
 /* ---[ 0x700: ILLEGAL INSN exception ]------------------------------------- */
 	.org 0x700
 	l.j	test_fail
-	l.nop
+	 l.nop
 
 /* ---[ 0x900: DTLB exception ]--------------------------------------------- */
 	.org 0x900
 	l.j	test_fail
-	l.nop
+	 l.nop
 
 /* ---[ 0xa00: itlb miss ]---------------------------------------------- */
         .org 0xa00
 
 	/* First check if we're expecting a miss in a delay slot - check r10 */
-	l.mfspr	r3,r0,OR1K_SPR_SYS_EEAR_BASE	/* Get EPC */ 				
-	l.nop	2                       /* Report PC for diagnostic purpose */ 	
-	/* Check SR[DSX] was as expected */ 					
-	l.mfspr	r8,r0,OR1K_SPR_SYS_SR_ADDR    	/* Get SR */ 				
-	l.andi	r8,r8,OR1K_SPR_SYS_SR_DSX_MASK	/* Clear all bits except DSX */		
-	l.xor	r8,r8,r10		/* r8 will be >0 if error */ 		
-	l.sfne	r8,r0								
-	l.bf	test_fail 							
-	l.nop									
-	
+	l.mfspr	r3,r0,OR1K_SPR_SYS_EEAR_BASE	/* Get EPC */
+	l.nop	2                       /* Report PC for diagnostic purpose */
+	/* Check SR[DSX] was as expected */
+	l.mfspr	r8,r0,OR1K_SPR_SYS_SR_ADDR    	/* Get SR */
+	l.andi	r8,r8,OR1K_SPR_SYS_SR_DSX_MASK	/* Clear all bits except DSX */
+	l.xor	r8,r8,r10		/* r8 will be >0 if error */
+	l.sfne	r8,r0
+	l.bf	test_fail
+	 l.nop
+
 	/* Simple itlb miss handler - install 1-1 mappings on misses */
 	l.mfspr	r12,r0,OR1K_SPR_SYS_EEAR_BASE /* Get the PC of the exception */
 	l.srli	r13,r12,13 /* Get the page number, divide by 8K, store in r13 */
@@ -125,28 +126,28 @@
 	/* Write it into the appropriate translate register  */
 	l.mtspr	r13,r15,OR1K_SPR_IMMU_ITLBW_TR_ADDR(0, 0)
 	/* MMU setup should now be complete, let's go back */
-	l.rfe	
-	
+	l.rfe
+
 /* ---[ 0xe00: TRAP error ]------------------------------------------------ */
 	.org 0xe00
 	l.j	test_fail
-	l.nop
-	
+	 l.nop
+
 /* =================================================== [ text section ] === */
 	.section  .text
 
-/* =================================================== [ start ] === */	
+/* =================================================== [ start ] === */
 
 	.global _start
 _start:
 	/* First initialise the instruction MMU */
-	
+
 	l.mfspr	r3,r0,OR1K_SPR_SYS_IMMUCFGR_ADDR
 	l.andi	r4,r3,OR1K_SPR_SYS_IMMUCFGR_NTS_MASK
 	l.srli	r4,r4,OR1K_SPR_SYS_IMMUCFGR_NTS_LSB
 	l.ori	r6,r0,1
 	l.sll	r3,r6,r4
-	
+
 	/* Setup the IMMU's TLBs - invalidate them */
 	l.movhi r4, hi(OR1K_SPR_IMMU_ITLBW_MR_ADDR(0, 0))
 	l.ori r4, r4, lo(OR1K_SPR_IMMU_ITLBW_MR_ADDR(0, 0))
@@ -157,18 +158,18 @@ _start:
 	l.addi r4, r4, 0x1
 	l.sfeq r3, r0
 	l.bnf 1b
-	l.addi r3, r3, -1
+	 l.addi r3, r3, -1
 
 	/* Enable MMU - we should get a miss for this page */
 	l.movhi	r10,0 /* Clear r10 - not expecting to be in a delay slot
 			when this TLB miss occurs */
-	
+
 	.extern lo_immu_en
 	/* Now enable the IMMU */
 	l.movhi r4, hi(lo_immu_en)
 	l.ori r4, r4, lo(lo_immu_en)
 	l.jalr r4
-	l.nop
+	 l.nop
 
 	/* Copy the 2 instructions from the ljr9_function function to
 	places which should cause TLB misses in the delay slot */
@@ -198,8 +199,8 @@ _start:
 	l.nop	2
 
 	l.jalr	r1
-	l.nop
-	
+	 l.nop
+
 	/* Tests finish */
 
 	/* Now do what we've done for the miss but put delay slot instruction
@@ -233,19 +234,19 @@ _start:
 	l.nop	2
 
 	l.jalr	r1
-	l.nop
-	
+	 l.nop
+
 
 	/* TODO - track and check the number of TLB misses we should
 	have incurred */
-	
+
 	/* Now repeat the tests with caches enabled if they weren't */
 	l.mfspr	r1,r0,OR1K_SPR_SYS_SR_ADDR
 	l.andi	r1,r1,OR1K_SPR_SYS_SR_ICE_MASK
 	l.sfeq	r0,r1  /* Set flag if caches not enabled */
 	l.bf	restart_with_caches_enabled
-	l.nop
-	
+	 l.nop
+
 test_ok:
 	l.movhi	r3,0x8000
 	l.ori	r3,r3,0x000d
@@ -261,7 +262,7 @@ test_fail:
 	l.nop	1
 
 restart_with_caches_enabled:
-	
+
 	/* Disable IMMU before restart*/
         l.mfspr r3,r0,OR1K_SPR_SYS_SR_ADDR
         l.xori  r3,r3,OR1K_SPR_SYS_SR_IME_MASK
@@ -270,9 +271,9 @@ restart_with_caches_enabled:
 	l.ori	r9,r9,lo(.L1)
         l.mtspr r0,r9,OR1K_SPR_SYS_EPCR_BASE
         l.rfe
-.L1:	
+.L1:
 	l.jal 	_cache_init
-	l.nop
+	 l.nop
 
 	/* Actually we won't want dcache enabled as we'll be reading
 	and writing instructions around the shop so will not want them
@@ -280,13 +281,13 @@ restart_with_caches_enabled:
         l.mfspr r3,r0,OR1K_SPR_SYS_SR_ADDR
         l.xori  r3,r3,OR1K_SPR_SYS_SR_DCE_MASK
         l.mtspr r0,r3,OR1K_SPR_SYS_SR_ADDR
-	
+
 	l.j     _start
-	l.nop
+	 l.nop
 
 	/* A simple function, which we will copy the instructions of
 	to different parts of memory */
 ljr9_function:
 	l.jr	r9
-	l.nop
+	 l.nop
 

--- a/native/or1k/or1k-ext.S
+++ b/native/or1k/or1k-ext.S
@@ -4,7 +4,7 @@
 	Very basic, testing
 
 	Julius Baxter, ORSoC AB, julius.baxter@orsoc.se
-	
+
 */
 //////////////////////////////////////////////////////////////////////
 ////                                                              ////
@@ -32,19 +32,17 @@
 //// from http://www.opencores.org/lgpl.shtml                     ////
 ////                                                              ////
 //////////////////////////////////////////////////////////////////////
-	
-#include <or1k-asm.h>	
+
+#include <or1k-asm.h>
 #include <or1k-sprs.h>
 #include "board.h"
 
-
-	
 /* =================================================== [ exceptions ] === */
 	.section .vectors, "ax"
 
 
 /* ---[ 0x100: RESET exception ]----------------------------------------- */
-        .org 0x100 	
+        .org 0x100
 	l.movhi r0, 0
 	/* Clear status register */
 	l.ori r1, r0, OR1K_SPR_SYS_SR_SM_MASK
@@ -59,15 +57,14 @@
 	l.jr    r4
 	l.nop
 
-	.org 0x600 	
+	.org 0x600
+	l.ori 	r3, r0, 0x600
 	l.nop 0x1
 
-	
 /* ---[ 0x700: Illegal instruction exception ]-------------------------- */
         .org 0x700
-	l.ori 	r3, r0, 1
+	l.ori 	r3, r0, 0x700
 	l.nop 	0x1
-
 
 /* =================================================== [ text ] === */
 	.section .text
@@ -75,16 +72,14 @@
 /* =================================================== [ start ] === */	
 
 	.global _start
-_start:	
+_start:
 	// Kick off test
 	l.jal   _main
 	l.nop
-	
-
 
 /* =================================================== [ main ] === */
-	
-	.global _main	
+
+	.global _main
 _main:
 	// l.exth tests first
 	l.ori 	r4,r0,0xffff
@@ -98,17 +93,17 @@ _main:
 	l.nop 	0x2
 	l.sfne	r8,r3
 	l.bf	fail
-	l.nop
+	 l.nop
 
 	l.ori	r8,r0,0xffff
 
 	l.exthz	r3,r4
 
 	l.nop 	0x2
-	
+
 	l.sfne	r8,r3
 	l.bf	fail
-	l.nop
+	 l.nop
 
 	l.exths	r3,r5
 
@@ -124,13 +119,13 @@ _main:
 
 	l.sfne	r3,r5
 	l.bf	fail
-	l.nop
+	 l.nop
 
 	// l.extb tests
-	
+
 	l.ori 	r4,r0,0x00ff
 	l.ori 	r5,r0,0x007f
-	
+
 	l.extbs	r3,r4
 
 	l.nop 	0x2
@@ -140,17 +135,17 @@ _main:
 
 	l.sfne	r8,r3
 	l.bf	fail
-	l.nop
+	 l.nop
 
 	l.ori	r8,r0,0x00ff
 
 	l.extbz	r3,r4
 
 	l.nop 	0x2
-	
+
 	l.sfne	r8,r3
 	l.bf	fail
-	l.nop
+	 l.nop
 
 	l.extbs	r3,r5
 
@@ -158,7 +153,7 @@ _main:
 
 	l.sfne	r3,r5
 	l.bf	fail
-	l.nop
+	 l.nop
 
 	l.extbz	r3,r5
 
@@ -166,7 +161,7 @@ _main:
 
 	l.sfne	r3,r5
 	l.bf	fail
-	l.nop
+	 l.nop
 
 	// l.extw tests - shouldn't change anything
 	l.movhi	r4,0xffff
@@ -175,7 +170,7 @@ _main:
 	l.extws	r3,r4
 
 	l.nop 	0x2
-	
+
 	l.sfne	r3,r4
 	l.bf	fail
 	l.nop
@@ -183,16 +178,16 @@ _main:
 	l.extwz	r3,r4
 
 	l.nop 	0x2
-	
+
 	l.sfne	r3,r4
 	l.bf	fail
-	l.nop
+	 l.nop
 
-	
+success:
 	l.movhi r3, hi(0x8000000d)
 	l.ori 	r3, r3, lo(0x8000000d)
 	l.nop 	0x2
-	l.ori 	r3, r0, 0	
+	l.ori 	r3, r0, 0
 	l.nop 	0x1
 
 fail:

--- a/native/or1k/or1k-icache.S
+++ b/native/or1k/or1k-icache.S
@@ -110,9 +110,9 @@ _main:
 
 	/* invalidate _test_area */
 
+test_ok:
 	l.movhi	r3, 0
-	l.jal	exit
-	 l.nop
+	l.nop	0x1
 
 /*
  * copies from the area pointed by r3->r4 to the place where r5 points to

--- a/native/or1k/or1k-mul-basic.S
+++ b/native/or1k/or1k-mul-basic.S
@@ -86,4 +86,5 @@ test_ok:
 	l.movhi	r3,0x8000
 	l.ori	r3,r3,0x000d
 	l.nop	0x2
+	l.movhi	r3,0x0
 	l.nop	0x1

--- a/native/runtests.sh
+++ b/native/runtests.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+#
+# SYNOPSIS
+#  ./runtests.sh [test_pattern]
+#
+# SUMMARY
+#
+# Runs all tests, captures output to log report PASS, FAIL and overall status
+# A successful process must exit with reporting
+#    report(0x8000000d)
+#    exit(0x00000000)
+# Each test must run within the set TEST_TIMEOUT or it will timeout and be
+# considered a failure
+
+DIR=`dirname $0`
+TARGET=mor1kx_cappuccino
+CORE=mor1kx-generic
+TEST_TIMEOUT="1m"
+
+test_count=0
+fail_count=0
+
+PASS="\e[32mPASS\e[0m"
+FAIL="\e[31mFAIL\e[0m"
+
+if [ ! -d $DIR/build/or1k ] ; then
+  echo "Cannot find any tests, did you build them?"
+  exit 1
+fi
+
+TEST_PATTERN=$1
+if [ -z $TEST_PATTERN ] ; then
+  TEST_PATTERN="or1k-*"
+fi
+
+echo > $TARGET.log
+
+# run tests
+
+for test_path in $DIR/build/or1k/${TEST_PATTERN}; do
+  test_name=`basename $test_path`
+  ((test_count++))
+
+  test_log=`mktemp -t $test_name.XXX.log`
+
+  date -u -Iseconds > $test_log
+  echo "Running: fusesoc sim $CORE --elf-load $test_path" >> $test_log
+
+  printf "%-60s" "Running $test_name"
+  if ! timeout $TEST_TIMEOUT fusesoc sim $CORE --elf-load $test_path >> $test_log 2>&1 ; then
+    echo "TIME OUT"
+    ((fail_count++))
+  else
+    if grep -q "exit(0x00000000)" $test_log ; then
+      echo -e "$PASS"
+    else
+      echo -e "$FAIL"
+      ((fail_count++))
+    fi
+  fi
+
+  cat $test_log >> $TARGET.log
+  rm $test_log
+done
+
+# finish up
+
+printf "%-60sTotal: %3d  FAIL: %3d\n" "Results" $test_count $fail_count
+
+if [ $fail_count -gt 0 ] ; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
The new toolchain requires to be told to not include the newlib startup runtime
for .S files.  This this by default.

Also, I created a test runner which loads up mor1kx-generic in fusesoc
and runs all of the tests.  Current output:

```
Running or1k-alignillegalinsn                               TIME OUT
Running or1k-backtoback_jmp                                 PASS
Running or1k-basic                                          PASS
Running or1k-cmov                                           PASS
Running or1k-cy                                             FAIL
Running or1k-dsx                                            PASS
Running or1k-dsxinsn                                        PASS
Running or1k-ext                                            FAIL
Running or1k-ffl1                                           PASS
Running or1k-icache                                         PASS
Running or1k-illegalinsn                                    PASS
Running or1k-illegalinsndelayslot                           PASS
Running or1k-insnfetchalign                                 PASS
Running or1k-insnfetcherror                                 PASS
Running or1k-intloop                                        TIME OUT
Running or1k-intmulticycle                                  TIME OUT
Running or1k-intsyscall                                     TIME OUT
Running or1k-inttickloop                                    TIME OUT
Running or1k-jmp                                            PASS
Running or1k-jr                                             PASS
Running or1k-lsu                                            PASS
Running or1k-lsualign                                       PASS
Running or1k-lsualigndelayslot                              PASS
Running or1k-lsuerror                                       PASS
Running or1k-lsuerrordelayslot                              PASS
Running or1k-lwjr                                           PASS
Running or1k-msync                                          PASS
Running or1k-mul-basic                                      FAIL
Running or1k-ov                                             PASS
Running or1k-regjmp                                         PASS
Running or1k-rfe                                            PASS
Running or1k-sf                                             PASS
Running or1k-sfbf                                           PASS
Running or1k-shiftopts                                      PASS
Running or1k-shortbranch                                    PASS
Running or1k-shortjump                                      PASS
Running or1k-systemcall                                     PASS
Running or1k-tickloop                                       PASS
Running or1k-tickrfforward                                  TIME OUT
Running or1k-ticksyscall                                    PASS
Running or1k-timer                                          PASS
Running or1k-trap                                           PASS
Running or1k-trapdelayslot                                  PASS
Results                                                     Total:  43 FAIL:   9
```